### PR TITLE
[CP-18] Fix menu rendering

### DIFF
--- a/cmspage/context_processors.py
+++ b/cmspage/context_processors.py
@@ -1,7 +1,9 @@
 from collections import defaultdict
 import logging
+from functools import cache
 from typing import List
 
+from django.conf import settings
 from django.http import HttpRequest
 from wagtail.models import Site
 
@@ -10,6 +12,17 @@ from .models import SiteVariables, MenuLink
 __all__ = ("navigation", "site_variables", "cmspage_context")
 
 logger = logging.getLogger("cmspage.context_processors")
+
+
+def _nav_icon_path(icon: str) -> str:
+
+    @cache
+    def _nav_icon_base():
+        return getattr(settings, "CMSPAGE_NAV_ICON_PATH", "images/icons")
+
+    if icon:
+        return f"{_nav_icon_base()}/{icon}.svg"
+    return ""
 
 
 def _nav_pages_for_site(site: Site, user_id: int) -> List[dict]:
@@ -24,7 +37,7 @@ def _nav_pages_for_site(site: Site, user_id: int) -> List[dict]:
             "id": link.id,
             "title": link.menu_title or link.menu_link_title,
             "type": link.menu_link_type,
-            "icon": link.menu_link_icon,
+            "icon": _nav_icon_path(link.menu_link_icon),
             "url": link.url,
             "children": [],
         }

--- a/cmspage/templates/cmspage/cmspage.html
+++ b/cmspage/templates/cmspage/cmspage.html
@@ -2,5 +2,4 @@
 
 {% block navigation-top %}{% endblock navigation-top %}
 {% block header %}{% include include.header %}{% endblock header %}
-
-{#{% block navigation-left %}{% include include.navigation %}{% endblock navigation-left %}#}
+{% block navigation-left %}{% include include.navigation %}{% endblock navigation-left %}

--- a/cmspage/templates/cmspage/includes/navigation.html
+++ b/cmspage/templates/cmspage/includes/navigation.html
@@ -4,9 +4,7 @@
 <div class="col-12 col-lg-2 px-3 py-1 py-lg-3">
   <button class="btn btn-primary d-lg-none float-start" type="button" data-bs-toggle="collapse"
           data-bs-target="#leftMenu" aria-expanded="false" aria-controls="leftMenu" title="Toggle Menu">
-    {% with icon_path="images/icons/"|add:item.icon|add:".svg" %}
-      <img src="{% static icon_path %}" title="Navigation" class="menu-icon">
-    {% endwith %}
+      <img src="{% static item.icon %}" title="Navigation" class="menu-icon">
   </button>
   <nav class="collapse d-lg-block" id="leftMenu">
     <ul class="nav menu-list">{% for item in navigation %}

--- a/cmspage/templates/cmspage/includes/navigation_item.html
+++ b/cmspage/templates/cmspage/includes/navigation_item.html
@@ -2,9 +2,7 @@
 {# include.navigation_item #}
 <li class="menu-item">
   <a href="{{ item.url }}" class="menu-link level-{{ level }}">
-    {% with icon_path="images/icons/"|add:item.icon|add:".svg" %}
-      <img src="{% static icon_path %}" title=item.title class="menu-icon">
-    {% endwith %}
+      <img src="{% static item.icon %}" title=item.title class="menu-icon">
     {{ item.title }}
   </a>
   {% if item.children %}

--- a/docs/CMSPAGE.md
+++ b/docs/CMSPAGE.md
@@ -199,7 +199,7 @@ This setting provides the directory that contains included template files.
 The default value is None, or blank, which means that the included templates are in the same directory as the main
 template.
 
-<a name="cmspage_include_files_files"></a>
+<a name="cmspage_template_include_files"></a>
 ### CMSPAGE_TEMPLATE_INCLUDE_FILES
 
 This setting is a list of template files that are used in cmspage templates.
@@ -256,9 +256,9 @@ For example:
 <a name="menus"></a>
 # Menus
 
-The cmspage package supports user-definable menus, containing links to a any wagtail page, to an external link, or to a document.
+The cmspage package supports user-definable menus, containing links to any wagtail page, to an external link, or to a document.
 The default menu rendering template uses the "icon" attribute of the menu link, as determined by its type
-Icons can ber found in the static folder within the cmspage app, in the path `images/icons`.
+Icons can be found in the static folder within the cmspage app, in the path `images/icons`.
 
 Menus are managed in Wagtail's admin interface, appearing as "Menu Links" on the main Wagtail menu.
 MenuLinks are wagtail snippets.

--- a/docs/CMSPAGE.md
+++ b/docs/CMSPAGE.md
@@ -126,6 +126,7 @@ However, CMSPage provides an alternative that allows templates to gracefully fal
 through the CMSTemplateMixin class.
 This mixin adds special handling through a number of Django settings that can vary this behaviour.
 
+<a name="cmspage_template_styles"></a>
 ### CMSPAGE_TEMPLATE_STYLES
 
 This setting is a list of none, one or more strings that represent CSS frameworks or sites.
@@ -162,6 +163,7 @@ with fallbacks to a default template where a company-specific template doesn't e
 Alternatively, it is possible to create versions of pages which can be used
 with different front-end CSS frameworks—such as "bootstrap5" or "tailwindcss".
 
+<a name="cmspage_template_base"></a>
 ### CMSPAGE_TEMPLATE_BASE
 
 This is the name of the base template that the CMSPage templates extend.
@@ -182,12 +184,14 @@ which, unless overridden, is effectively equivalent to using the string literal:
 {% extends "cmspage/cmspage.html" %}
 ```
 
+<a name="cmspage_template_base_dir"></a>
 ### CMSPAGE_TEMPLATE_BASE_DIR
 
 By default, models deriving from `CMSPageBase` use the app name of the model.
 This setting allows this to be overridden so that the entire hierarchy of templates used
 is consistent, even across apps.
 
+<a name="cmspage_template_include_dir"></a>
 ### CMSPAGE_TEMPLATE_INCLUDE_DIR
 
 This setting provides the directory that contains included template files.
@@ -195,6 +199,7 @@ This setting provides the directory that contains included template files.
 The default value is None, or blank, which means that the included templates are in the same directory as the main
 template.
 
+<a name="cmspage_include_files_files"></a>
 ### CMSPAGE_TEMPLATE_INCLUDE_FILES
 
 This setting is a list of template files that are used in cmspage templates.
@@ -224,6 +229,7 @@ DEFAULT_TEMPLATE_INCLUDE_NAMES = [
 
 This setting may be either a list of strings or a space and/or comma-separated string.
 
+<a name="cmspage_include_files_files_extra"></a>
 ### CMSPAGE_TEMPLATE_INCLUDE_FILES_EXTRA
 
 This setting is a list of additional include files that can be used as cmspage included templates.
@@ -246,3 +252,20 @@ For example:
 {% include include.main %}
 {% include include.footer %}
 ```
+
+<a name="menus"></a>
+# Menus
+
+The cmspage package supports user-definable menus, containing links to a any wagtail page, to an external link, or to a document.
+The default menu rendering template uses the "icon" attribute of the menu link, as determined by its type
+Icons can ber found in the static folder within the cmspage app, in the path `images/icons`.
+
+Menus are managed in Wagtail's admin interface, appearing as "Menu Links" on the main Wagtail menu.
+MenuLinks are wagtail snippets.
+MenuLinks are created per site, and link to an Wagtail Page model, a Wagtail document model or an external URL.
+When linking to an existing page, that page must have the "show in menus" item checked in order to be eligible. Menu Title is mandatory for external links, otherwise the menu title is taken from the linked page or document unless overridden by explicitly defining the title for the MenuLink.
+One, and only one, "Link To" item can be selected.
+
+Submenus are created by linking a MenuItem to a "parent" MenuLink.
+
+The "Order" field can be used to override the order in which links are displayed.


### PR DESCRIPTION
- Adjusted css for menu items
- add new setting CMSPAGE_NAV_ICON_PATH, default `images/icons`
- documented MenuLinks and the Wagtail menu editor

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix menu rendering issues by adjusting CSS and icon paths, introduce a new setting for navigation icon paths, enhance the `MenuLink` model with additional validation and help text, and update documentation to include information on `MenuLinks` and the Wagtail menu editor.

New Features:
- Introduce a new setting `CMSPAGE_NAV_ICON_PATH` to specify the path for navigation icons, defaulting to `images/icons`.

Bug Fixes:
- Fix menu rendering by adjusting the CSS and ensuring the correct icon paths are used in the navigation templates.

Enhancements:
- Improve the `MenuLink` model by adding validation to ensure that external URLs require a title and updating help texts for clarity.
- Modify the caching behavior of `MenuLink` to be dependent on the `DEBUG` setting.

Documentation:
- Document the `MenuLinks` and the Wagtail menu editor in the CMSPage documentation, including details on menu management and configuration.

<!-- Generated by sourcery-ai[bot]: end summary -->