### PR TITLE
Update title block template and sass

### DIFF
--- a/cmspage/templates/blocks/title_block.html
+++ b/cmspage/templates/blocks/title_block.html
@@ -1,7 +1,8 @@
   <div class="row">
-    <div class="col-md-10 offset-md-1">
-      <h3 class="inner-heading mb-0">
+    <div class="col-md-12">
+      <h2 class="inner-heading mb-0">
         {{ value.text }}
-      </h3>
+      </h2>
+      <hr class="heading-hr"/>
     </div>
   </div>


### PR DESCRIPTION
- associated scss items
- rjf_init: add title to all non-home pages

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance the title block template by adjusting the column width to full and changing the heading level from h3 to h2, along with adding a horizontal rule for visual separation.

Enhancements:
- Update the title block template to use a full-width column and change the heading from h3 to h2.

<!-- Generated by sourcery-ai[bot]: end summary -->