### PR TITLE
Revert image and text block mixin

### DIFF
--- a/cmspage/static/js/social-link-block.js
+++ b/cmspage/static/js/social-link-block.js
@@ -1,0 +1,49 @@
+const SOCIAL_NAMES = {
+  "discord": "Discord",
+  "envelope": "Email",
+  "facebook": "Facebook",
+  "github": "GitHub",
+  "instagram": "Instagram",
+  "linkedin": "LinkedIn",
+  "medium": "Medium",
+  "facebook-messenger": "Messenger",
+  "pinterest": "Pinterest",
+  "reddit": "Reddit",
+  "rss": "RSS",
+  "skype": "Skype",
+  "slack": "Slack",
+  "snapchat": "Snapchat",
+  "telegram": "Telegram",
+  "tiktok": "TikTok",
+  "tumblr": "Tumblr",
+  "twitch": "Twitch",
+  "twitter": "Twitter",
+  "vimeo": "Vimeo",
+  "whatsapp": "WhatsApp",
+  "X": "X",
+  "youtube": "YouTube",
+  "zoom": "Zoom"
+}
+
+class SocialLinkBlockDefinition extends window.wagtailStreamField.blocks.StructBlockDefinition {
+
+  render(placeholder, prefix, initialState, initialError) {
+    const block = super.render(
+        placeholder,
+        prefix,
+        initialState,
+        initialError,
+    )
+
+    const iconSelect = document.getElementById(prefix + "-icon")
+    const nameInput = document.getElementById(prefix + "-name")
+    const updateNameInput = () => {
+        nameInput.value = SOCIAL_NAMES[iconSelect.value] || ''
+    }
+    updateNameInput()
+    iconSelect.addEventListener('change', updateNameInput)
+    return block
+  }
+}
+
+window.telepath.register('cmspage.blocks.SocialLinkBlock', SocialLinkBlockDefinition)

--- a/cmspage/templates/blocks/socials_block.html
+++ b/cmspage/templates/blocks/socials_block.html
@@ -2,14 +2,16 @@
 
 <div class="row {{ value.inset }} {{ value.palette }} justify-content-center align-items-center">
   {% for social in value.links %}
+    {% if social.url %}
     <div class="col-auto text-center">
-      {% if social.url %}<a href="{{ social.url }}" title="{{ social.name }}" class="text-decoration-none text-reset" target="_blank">{% endif %}
+      <a href="{{ social.url }}" title="{{ social.name }}" class="text-decoration-none text-reset" target="_blank">
       <div class="social-icon">
         {% with social_icon="cmspage/icons/social/"|add:social.icon|add:".svg" %}
         {% include social_icon %}
         {% endwith %}
       </div>
-      {% if social.url %}</a>{% endif %}
+      </a>
     </div>
+    {% endif %}
   {% endfor %}
 </div>


### PR DESCRIPTION
- Using a mixin does not work well with wagtail blocks editors and needs to be done differently. Rather than overcomplicate this, instead repeat the fields as required.

- Experimental social-link-block js to auto-fill name based on the selected icon
- Only render social links that have a URL (avoids preview issue)

## Summary by Sourcery

Revert the use of a mixin in the ImageAndTextBlock to improve compatibility with Wagtail block editors and add JavaScript functionality to auto-fill social media names based on selected icons. Ensure only social links with URLs are rendered to avoid preview issues.

New Features:
- Introduce JavaScript functionality to auto-fill the social media name based on the selected icon in the SocialLinkBlock.

Enhancements:
- Refactor the ImageAndTextBlock to remove the mixin and directly include fields, improving compatibility with Wagtail block editors.