### PR TITLE
Add `crop` option to image rendering and update CMS page types

### DIFF
--- a/cmspage/models/cms_form.py
+++ b/cmspage/models/cms_form.py
@@ -9,8 +9,8 @@ class CMSFormPage(CMSPageBase):
     A specialized CMS page type designed for building forms.
     """
     page_description = "This page type is for building forms"
-    parent_page_types = ["wagtailcore.Page"]
-    subpage_types = []
+    # parent_page_types = ["cmspage.CMSHomePage", "cmspage.CMSPage"]
+    # subpage_types = []
 
     # Extend body_blocks like CMSHomePage but without the hero block
     body_blocks = [

--- a/cmspage/models/cms_page.py
+++ b/cmspage/models/cms_page.py
@@ -117,7 +117,7 @@ class CMSPage(CMSPageBase):
     page_description = "This page type is for general content and can be used for most purposes."
     # Default implementation of CMSPage
     parent_page_types = ["cmspage.CMSHomePage", "cmspage.CMSPage"]
-    subpage_types = ["cmspage.CMSPage", "wagtailcore.Page"]
+    subpage_types = ["cmspage.CMSPage", "wagtailcore.Page", "cmspage.CMSFormPage"]
 
     class Meta:
         app_label = "cmspage"
@@ -151,7 +151,7 @@ class CMSFooterPage(AbstractCMSPage):
 class CMSHomePage(CMSPageBase):
     page_description = "This page type is only for a site home page."
     parent_page_types = ["wagtailcore.Page"]
-    subpage_types = ["cmspage.CMSPage", "wagtailcore.Page", "cmspage.CMSFooterPage"]
+    subpage_types = ["cmspage.CMSPage", "wagtailcore.Page", "cmspage.CMSFooterPage", "cmspage.CMSFormPage"]
     max_count = 1
 
     body_blocks = [

--- a/cmspage/templates/blocks/cards_block.html
+++ b/cmspage/templates/blocks/cards_block.html
@@ -19,7 +19,7 @@
         <div class="card-body p-1">
           {% if card.image %}
             <picture>
-              {% render_image card.image orientation=card.orientation|lower size=card.size|lower responsive=card.responsive rounded=value.rounded %}
+              {% render_image card.image orientation=card.orientation|lower size=card.size|lower responsive=card.responsive rounded=value.rounded crop=self.crop %}
             </picture>
           {% endif %}
           <div class="px-2 py-1 card-block-text d-flex flex-column {{ card.justify }} flex-grow-1 mt-auto">

--- a/cmspage/templates/blocks/hero_block.html
+++ b/cmspage/templates/blocks/hero_block.html
@@ -2,7 +2,7 @@
 <div class="p-3 m-5 text-center {{ self.inset }} {{ self.palette }}">
   <div class="image-container" style="z-index: 1;">
     <picture>
-      {% render_image self.image orientation=self.orientation|lower size=self.size|lower responsive=self.responsive %}
+      {% render_image self.image orientation=self.orientation|lower size=self.size|lower responsive=self.responsive rounded=self.rounded crop=self.crop %}
     </picture>
   </div>
 </div>

--- a/cmspage/templates/blocks/image_and_text_block.html
+++ b/cmspage/templates/blocks/image_and_text_block.html
@@ -1,12 +1,12 @@
 {% load static wagtailcore_tags wagtailimages_tags cmspage_tags %}
 
-{% if self.image_alignment == "full" %}
+{% if self.image_alignment == "full" or self.image_alignment == "center" %}
 {% if self.link.link_url %}<a href="{{ self.link.link_url }}" class="text-decoration-none text-reset">{% endif %}
 
-<div class="row position-relative {{ self.justify }} {{ self.inset }} {{ self.palette }}">
+<div class="row position-relative {{ self.justify }}{% if self.image_alignment == "full"%} w-100{% endif %} {{ self.inset }} {{ self.palette }}">
   {% if self.image %}
     <picture>
-      {% render_image self.image orientation=self.orientation|lower size=self.size|lower responsive=self.responsive rounded=self.rounded %}
+      {% render_image self.image orientation=self.orientation|lower size=self.size|lower responsive=self.responsive rounded=self.rounded crop=self.crop %}
     </picture>
   {% endif %}
   <div class="{% if self.overlay %} overlay-top{% endif %} py-3 block-text {{ self.justify }}">
@@ -32,7 +32,7 @@
   {% if self.image %}
   <div class="col-auto{% if self.image_alignment == "right" %} text-end{% else %} text-start{% endif %}">
     <picture>
-      {% render_image self.image orientation=self.orientation|lower size=self.size|lower responsive=self.responsive rounded=self.rounded %}
+      {% render_image self.image orientation=self.orientation|lower size=self.size|lower responsive=self.responsive rounded=self.rounded crop=self.crop %}
     </picture>
   </div>
   {% endif %}

--- a/cmspage/templates/blocks/large_image_block.html
+++ b/cmspage/templates/blocks/large_image_block.html
@@ -3,7 +3,7 @@
 <div class="row mb-2 text-center {{ self.inset }} {{ self.bg.background }} {{ self.bg.opacity }}">
   <div class="col">
     <picture>
-      {% render_image self.image orientation=self.orientation|lower size=self.size|lower responsive=self.responsive %}
+      {% render_image self.image orientation=self.orientation|lower size=self.size|lower responsive=self.responsive rounded=self.rounded crop=self.crop %}
     </picture>
   </div>
 </div>

--- a/cmspage/templates/blocks/small_image_and_text_block.html
+++ b/cmspage/templates/blocks/small_image_and_text_block.html
@@ -4,7 +4,7 @@
   {% if value.image %}
   <div class="col-auto d-flex align-items-center p-1">
     <picture>
-      {% render_image value.image orientation=value.orientation|lower size=value.size|lower responsive=value.responsive %}
+      {% render_image value.image orientation=value.orientation|lower size=value.size|lower responsive=value.responsive rounded=self.rounded crop=self.crop %}
     </picture>
   </div>
   {% endif %}


### PR DESCRIPTION
Enhanced the `render_image` template tag across multiple blocks to include a `crop` option for better image control. Adjusted CMS page types to allow `CMSFormPage` as a subpage for greater flexibility in form creation.

## Summary by Sourcery

Add `crop` option to image rendering and update CMS page type configurations to improve image control and page hierarchy flexibility

New Features:
- Added `crop` parameter to `render_image` template tag across multiple block templates to provide more precise image rendering control

Enhancements:
- Updated image block templates to support optional cropping for images
- Modified CMS page type configurations to allow more flexible page hierarchies

Chores:
- Removed restrictive page type constraints for CMSFormPage
- Updated subpage type configurations for CMSPage and CMSHomePage to include CMSFormPage