### PR TITLE
Refactor `_prefetch_block_images`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,4 @@ dist/
 /.claude
 /cmspage/scss/*.css
 /cmspage/scss/*.css.map
-/original_images/
-/tests/original_images/
+original_images/

--- a/cmspage/models/cms_page.py
+++ b/cmspage/models/cms_page.py
@@ -3,6 +3,7 @@ from modelcluster.contrib.taggit import ClusterTaggableManager
 from wagtail.admin.panels import FieldRowPanel, FieldPanel
 from wagtail.embeds import blocks as embed_blocks
 from wagtail.fields import StreamField
+from wagtail.images.models import Image as WagtailImage
 from wagtail.models import Page
 
 import cmspage.blocks as cmsblocks
@@ -123,17 +124,13 @@ class CMSPageBase(AbstractCMSPage):
 
             # Handle specific block types that contain images
             if block_type == "cards":
-                # Cards block has a "cards" field which is a list of cards, each with an "image" field
+                # Cards block has a "cards" field, which is a list of cards, each with an "image" field
                 cards = block.value.get("cards", [])
                 ids.extend(card["image"].id for card in cards if card.get("image"))
             elif block_type == "carousel":
-                # Carousel block has a "carousel" field which is a list of carousel items, each with a "carousel_image" field
+                # Carousel block has a "carousel" field, which is a list of carousel items, each with a "carousel_image" field
                 carousel_items = block.value.get("carousel", [])
-                ids.extend(
-                    item["carousel_image"].id
-                    for item in carousel_items
-                    if item.get("carousel_image")
-                )
+                ids.extend(item["carousel_image"].id for item in carousel_items if item.get("carousel_image"))
             elif block_type in ["image_and_text", "large_image", "small_image_and_text", "hero"]:
                 # These blocks have an "image" field directly
                 if block.value.get("image"):
@@ -143,14 +140,18 @@ class CMSPageBase(AbstractCMSPage):
                 # Check for common image field names in the block's value
                 if "image" in block.value and block.value["image"] and hasattr(block.value["image"], "id"):
                     ids.append(block.value["image"].id)
-                elif "carousel_image" in block.value and block.value["carousel_image"] and hasattr(block.value["carousel_image"], "id"):
+                elif (
+                    "carousel_image" in block.value
+                    and block.value["carousel_image"]
+                    and hasattr(block.value["carousel_image"], "id")
+                ):
                     ids.append(block.value["carousel_image"].id)
 
         elif isinstance(block, list):
             for item in block:
                 ids.extend(cls._extract_image_ids_from_block(item))
 
-        elif hasattr(block, "id"):
+        elif hasattr(block, "id") and isinstance(block, WagtailImage):
             ids.append(block.id)
 
         elif isinstance(block, dict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wagtail-cmspage"
-version = "2025.7.2"
+version = "2025.7.3"
 description = "Base extensible and comprehensive: CMSPage type for Wagtail"
 authors = [
   { name = "David Nugent", email = "davidn@uniquode.io" }
@@ -8,9 +8,9 @@ authors = [
 license = { text = "MIT" }
 readme = "README.md"
 dependencies = [
-    "django >= 5.1",
-    "pillow-heif >= 0.21",
-    "wagtail >= 6.3",
+    "django >= 5.2",
+    "pillow-heif >= 1.0",
+    "wagtail >= 7.0",
 ]
 requires-python = ">= 3.11"
 

--- a/tests/test_cmspage_image_prefetch.py
+++ b/tests/test_cmspage_image_prefetch.py
@@ -119,6 +119,100 @@ class TestCMSPageImagePrefetch:
         assert len(image_ids) == 1
         assert self.image1.id in image_ids
 
+    def test_extract_image_ids_from_title_block(self):
+        """Test extracting image IDs from a title block (which has no images)"""
+        # Create a mock title block
+        mock_block = MagicMock()
+        mock_block.block_type = "title"
+        mock_block.value = {
+            "text": "This is a title",
+            "cursive": False,
+            "justify": "center",
+            "palette": "warning",
+            "inset": "small",
+        }
+
+        # Call the method
+        image_ids = CMSPage._extract_image_ids_from_block(mock_block)
+
+        # Assert that no image IDs were extracted
+        assert len(image_ids) == 0
+
+    def test_extract_image_ids_from_richtext_with_title_block(self):
+        """Test extracting image IDs from a richtext_with_title block (which has no images)"""
+        # Create a mock richtext_with_title block
+        mock_block = MagicMock()
+        mock_block.block_type = "richtext"
+        mock_block.value = {
+            "title": "This is a title",
+            "cursive": False,
+            "content": "<p>This is some rich text content</p>",
+            "justify": "left",
+            "palette": "warning",
+            "inset": "small",
+        }
+
+        # Call the method
+        image_ids = CMSPage._extract_image_ids_from_block(mock_block)
+
+        # Assert that no image IDs were extracted
+        assert len(image_ids) == 0
+
+    def test_extract_image_ids_from_copyright_block(self):
+        """Test extracting image IDs from a copyright block (which has no images)"""
+        # Create a mock copyright block
+        mock_block = MagicMock()
+        mock_block.block_type = "copy"
+        mock_block.value = {
+            "copyright": "© 2025 Example Company",
+            "palette": "warning",
+            "inset": "small",
+        }
+
+        # Call the method
+        image_ids = CMSPage._extract_image_ids_from_block(mock_block)
+
+        # Assert that no image IDs were extracted
+        assert len(image_ids) == 0
+
+    def test_extract_image_ids_from_call_to_action_block(self):
+        """Test extracting image IDs from a call_to_action block (which has no images)"""
+        # Create a mock call_to_action block
+        mock_block = MagicMock()
+        mock_block.block_type = "cta"
+        mock_block.value = {
+            "title": "Call to Action",
+            "cursive": False,
+            "text": "<p>Click here to learn more</p>",
+            "justify": "left",
+            "palette": "warning",
+            "inset": "small",
+            "link": {"button_title": "Learn More", "page_link": None, "doc_link": None, "extra_link": "/learn-more"},
+        }
+
+        # Call the method
+        image_ids = CMSPage._extract_image_ids_from_block(mock_block)
+
+        # Assert that no image IDs were extracted
+        assert len(image_ids) == 0
+
+    def test_extract_image_ids_from_new_section_block(self):
+        """Test extracting image IDs from a new_section block (which has no images)"""
+        # Create a mock new_section block
+        mock_block = MagicMock()
+        mock_block.block_type = "new_section"
+        mock_block.value = {
+            "height": "medium",
+            "palette": "warning",
+            "inset": "small",
+        }
+
+        # Call the method
+        image_ids = CMSPage._extract_image_ids_from_block(mock_block)
+
+        # Assert that no image IDs were extracted
+        assert len(image_ids) == 0
+
     def test_image_id_deduplication(self):
         # sourcery skip: extract-duplicate-method
         """Test that image IDs are deduplicated when prefetching"""

--- a/uv.lock
+++ b/uv.lock
@@ -821,7 +821,7 @@ wheels = [
 
 [[package]]
 name = "wagtail-cmspage"
-version = "2025.7.2"
+version = "2025.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "django" },
@@ -846,10 +846,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=5.1" },
+    { name = "django", specifier = ">=5.2" },
     { name = "hvac", marker = "extra == 'vault'", specifier = ">=1.1.1" },
-    { name = "pillow-heif", specifier = ">=0.21" },
-    { name = "wagtail", specifier = ">=6.3" },
+    { name = "pillow-heif", specifier = ">=1.0" },
+    { name = "wagtail", specifier = ">=7.0" },
 ]
 provides-extras = ["vault"]
 


### PR DESCRIPTION
Improved image ID extraction logic and add comprehensive tests for various block types.

## Summary by Sourcery

Refactor image prefetching by extracting block-specific image ID logic into a new helper method and improve coverage with tests for various block types.

Enhancements:
- Introduce _extract_image_ids_from_block to handle image ID extraction based on block types
- Refactor _prefetch_block_images to use the new helper method instead of inline recursive logic

Tests:
- Add tests for image ID extraction from title, richtext_with_title, copy, cta, and new_section blocks to ensure no images are returned