### PR TITLE
Add missing theme switcher include

### DIFF
--- a/cmspage/scss/partials/_theme-switcher.scss
+++ b/cmspage/scss/partials/_theme-switcher.scss
@@ -1,0 +1,158 @@
+/**
+ * Theme Switcher Logic
+ * Handles theme switching between light, dark, and auto modes
+ */
+
+// Auto mode support - follow system preference when no theme is explicitly set
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    // Dark mode colors - these should match the [data-theme="dark"] values
+    // Each site needs to define these in their _color-variables.scss
+
+    // The actual color values are defined in each site's _color-variables.scss
+    // This just ensures auto mode works correctly
+  }
+}
+
+// Smooth transitions when switching themes
+:root {
+  // Add transitions to color changes for smooth theme switching
+  * {
+    transition: color 0.3s ease-in-out,
+                background-color 0.3s ease-in-out,
+                border-color 0.3s ease-in-out,
+                box-shadow 0.3s ease-in-out;
+  }
+}
+
+// Disable transitions during page load to prevent flash
+.no-transitions * {
+  transition: none !important;
+}
+
+// Theme indicator classes (optional - for UI feedback)
+[data-theme="light"] .theme-indicator-light,
+[data-theme="dark"] .theme-indicator-dark,
+:root:not([data-theme]) .theme-indicator-auto {
+  display: block;
+}
+
+[data-theme="light"] .theme-indicator-dark,
+[data-theme="light"] .theme-indicator-auto,
+[data-theme="dark"] .theme-indicator-light,
+[data-theme="dark"] .theme-indicator-auto,
+:root:not([data-theme]) .theme-indicator-light,
+:root:not([data-theme]) .theme-indicator-dark {
+  display: none;
+}
+
+// Utility classes for forcing specific themes on elements
+.force-light-theme {
+  color-scheme: light;
+  // Will use light mode colors even in light mode
+}
+
+.force-dark-theme {
+  color-scheme: dark;
+  // Will use dark mode colors even in dark mode
+}
+
+// Helper for high contrast mode support
+@media (prefers-contrast: high) {
+  :root {
+    // Increase contrast for accessibility
+    --cp-contrast-boost: 1.2;
+  }
+}
+
+// Print styles - always use light theme for printing
+@media print {
+  :root {
+    // Force light mode colors for printing
+    // Each site should define print-friendly colors in their _color-variables.scss
+  }
+}
+
+// Fixed theme switcher positioning
+.theme-switcher-fixed {
+  position: fixed;
+  top: 2px;
+  right: 2px;
+  z-index: 1050; // Above most Bootstrap components but below modals
+
+  .btn-group-vertical {
+    box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.15);
+    border-radius: 0.375rem;
+    overflow: hidden;
+
+    .btn {
+      border-radius: 0;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+      backdrop-filter: blur(4px);
+      background-color: rgba(255, 255, 255, 0.9);
+      color: #333; // Darker text for better contrast
+
+      &:last-child {
+        border-bottom: none;
+      }
+
+      &.active {
+        background-color: #39aa9b !important; // Use explicit teal for visibility in all modes
+        color: white !important;
+        border-color: #39aa9b !important;
+      }
+
+      // Ensure icons are visible in light mode
+      i {
+        color: #333;
+      }
+
+      &.active i {
+        color: white !important;
+      }
+    }
+  }
+
+  // Mobile responsiveness
+  @media (max-width: 576px) {
+    top: 2px;
+    right: 2px;
+
+    .btn-group-vertical .btn {
+      padding: 0.25rem 0.375rem;
+      font-size: 0.875rem;
+    }
+  }
+}
+
+[data-theme="dark"] .theme-switcher-fixed {
+  .btn-group-vertical .btn {
+    background-color: rgba(0, 0, 0, 0.9);
+    color: #f8f9fa; // Light text for dark mode
+    border-color: rgba(255, 255, 255, 0.3);
+
+    // Ensure icons are visible in dark mode
+    i {
+      color: #f8f9fa;
+    }
+
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.2);
+      color: white;
+
+      i {
+        color: white;
+      }
+    }
+
+    &.active {
+      background-color: #39aa9b !important; // Use the original teal accent for better visibility
+      color: white !important;
+      border-color: #39aa9b !important;
+
+      i {
+        color: white !important;
+      }
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wagtail-cmspage"
-version = "2025.7.5"
+version = "2025.7.6"
 description = "Base extensible and comprehensive: CMSPage type for Wagtail"
 authors = [
   { name = "David Nugent", email = "davidn@uniquode.io" }

--- a/uv.lock
+++ b/uv.lock
@@ -711,7 +711,7 @@ wheels = [
 
 [[package]]
 name = "testcontainers"
-version = "4.10.0"
+version = "4.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docker" },
@@ -720,9 +720,9 @@ dependencies = [
     { name = "urllib3" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/49/9c618aff1c50121d183cdfbc3a4a5cf2727a2cde1893efe6ca55c7009196/testcontainers-4.10.0.tar.gz", hash = "sha256:03f85c3e505d8b4edeb192c72a961cebbcba0dd94344ae778b4a159cb6dcf8d3", size = 63327, upload-time = "2025-04-02T16:13:27.582Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/62/01d9f648e9b943175e0dcddf749cf31c769665d8ba08df1e989427163f33/testcontainers-4.12.0.tar.gz", hash = "sha256:13ee89cae995e643f225665aad8b200b25c4f219944a6f9c0b03249ec3f31b8d", size = 66631, upload-time = "2025-07-21T20:32:26.37Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/0a/824b0c1ecf224802125279c3effff2e25ed785ed046e67da6e53d928de4c/testcontainers-4.10.0-py3-none-any.whl", hash = "sha256:31ed1a81238c7e131a2a29df6db8f23717d892b592fa5a1977fd0dcd0c23fc23", size = 107414, upload-time = "2025-04-02T16:13:25.785Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e8/9e2c392e5d671afda47b917597cac8fde6a452f5776c4c9ceb93fbd2889f/testcontainers-4.12.0-py3-none-any.whl", hash = "sha256:26caef57e642d5e8c5fcc593881cf7df3ab0f0dc9170fad22765b184e226ab15", size = 111791, upload-time = "2025-07-21T20:32:25.038Z" },
 ]
 
 [[package]]
@@ -821,7 +821,7 @@ wheels = [
 
 [[package]]
 name = "wagtail-cmspage"
-version = "2025.7.5"
+version = "2025.7.6"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
## Summary by Sourcery

Add missing theme switcher SCSS include and bump package version

New Features:
- Introduce _theme-switcher.scss partial with light, dark, and auto theme logic, including smooth transitions, high-contrast, and print styles
- Implement fixed-position theme switcher UI styling with responsive and mode-specific variants

Build:
- Bump project version to 2025.7.6